### PR TITLE
Allow setting title of customtime in constructor

### DIFF
--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -53,7 +53,7 @@ class CustomTime extends Component {
   setOptions(options) {
     if (options) {
       // copy all options that we know
-      util.selectiveExtend(['moment', 'locale', 'locales', 'id'], this.options, options);
+      util.selectiveExtend(['moment', 'locale', 'locales', 'id', 'title'], this.options, options);
     }
   }
 


### PR DESCRIPTION
This allows setting of custom time bar title in the constructor, allowing calls like the following to correctly display the title.

`graph.addCustomTime(new Date(1531135747 * 1000), 'custom_id', { title: 'custom title' });`