### PR TITLE
Addittional fix for page scrolling over timeline

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -222,18 +222,21 @@ class Core {
       // Don't preventDefault if you can't scroll
       if (!this.options.verticalScroll && !this.options.horizontalScroll) return;
 
-      // Prevent default actions caused by mouse wheel
-      // (else the page and timeline both scroll)
-      event.preventDefault();
-
       if (this.options.verticalScroll && Math.abs(deltaY) >= Math.abs(deltaX)) {
         const current = this.props.scrollTop;
         const adjusted = current + deltaY;
 
         if (this.isActive()) {
-          this._setScrollTop(adjusted);
-          this._redraw();
-          this.emit('scroll', event);
+          const newScrollTop = this._setScrollTop(adjusted);
+
+          if (newScrollTop !== current) {
+            this._redraw();
+            this.emit('scroll', event);
+
+            // Prevent default actions caused by mouse wheel
+            // (else the page and timeline both scroll)
+            event.preventDefault();
+          }
         }
       } else if (this.options.horizontalScroll) {
         const delta = Math.abs(deltaX) >= Math.abs(deltaY) ? deltaX : deltaY;
@@ -250,6 +253,8 @@ class Core {
           event
         };
         this.range.setRange(newStart, newEnd, options);
+
+        event.preventDefault();
       }
     }
 


### PR DESCRIPTION
(adapted copy of #4143 on vis)

After this fix, Timeline only does preventDefault on a vertical scroll event if the timeline has actually been scrolled. AFAIK this behaviour would be consistent with what all popular GUI systems do.