### PR TITLE
Fixes issue #63 - Reordering items not working correctly

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -127,6 +127,8 @@ class Group {
    * @param {Object} data   Group data, can contain properties content and className
    */
   setData(data) {
+    if (this.itemSet.groupTouchParams.isDragging) return
+
     // update contents
     let content;
     let templateFunction;

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -127,7 +127,7 @@ class Group {
    * @param {Object} data   Group data, can contain properties content and className
    */
   setData(data) {
-    if (this.itemSet.groupTouchParams.isDragging) return
+    if (this.itemSet.groupTouchParams.isDragging) return;
 
     // update contents
     let content;

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -211,9 +211,12 @@ class ItemSet extends Component {
     this.popup = null;
 
     this.touchParams = {}; // stores properties while dragging
-    this.groupTouchParams = {};
+    this.groupTouchParams = {
+      group: null,
+      isDragging: false
+    };
+  
     // create the HTML DOM
-
     this._create();
 
     this.setOptions(options);
@@ -1845,19 +1848,29 @@ class ItemSet extends Component {
       util.addClassName(group.dom.label, collapsedDirClassName);
     }
   }
-
+  
+  toggleGroupDragClassName(group) {
+    group.dom.label.classList.toggle('timeline-group-is-dragging');
+    group.dom.foreground.classList.toggle('timeline-group-is-dragging');
+  }
+  
   _onGroupDragStart(event) {
-      if (this.options.groupEditable.order) {
-          this.groupTouchParams.group = this.groupFromTarget(event);
-          
-          if (this.groupTouchParams.group) {
-              event.stopPropagation();
-              
-              this.groupTouchParams.originalOrder = this.groupsData.getIds({
-                order: this.options.groupOrder
-              });
-          }
+    if (this.groupTouchParams.isDragging) return;
+
+    if (this.options.groupEditable.order) {
+      this.groupTouchParams.group = this.groupFromTarget(event);
+      
+      if (this.groupTouchParams.group) {
+        event.stopPropagation();      
+        
+        this.groupTouchParams.isDragging = true;
+        this.toggleGroupDragClassName(this.groupTouchParams.group);
+        
+        this.groupTouchParams.originalOrder = this.groupsData.getIds({
+          order: this.options.groupOrder
+        });
       }
+    }
   }
 
   _onGroupDrag(event) {
@@ -1964,6 +1977,8 @@ class ItemSet extends Component {
   }
 
   _onGroupDragEnd(event) {
+    this.groupTouchParams.isDragging = false;
+
     if (this.options.groupEditable.order && this.groupTouchParams.group) {
       event.stopPropagation();
           
@@ -2021,7 +2036,9 @@ class ItemSet extends Component {
       });
 
       me.body.emitter.emit('groupDragged', { groupId: id });
-      }
+      this.toggleGroupDragClassName(this.groupTouchParams.group);
+      this.groupTouchParams.group = null;
+    }
   }
 
   /**

--- a/lib/timeline/component/css/labelset.css
+++ b/lib/timeline/component/css/labelset.css
@@ -25,6 +25,10 @@
   cursor: pointer;
 }
 
+.timeline-group-is-dragging {
+  background: rgba(0, 0, 0, .1);
+}
+
 .timeline-labelset .timeline-label:last-child {
   border-bottom: none;
 }


### PR DESCRIPTION
Fixes issue #63. This main bug is caused when the target of the groupDrag event is the `group.dom.inner` element since the `group.setData` method is called which removes the `group.dom.inner` element completely and thus the reference to the drag element is lost and the group stops dragging. 

- This pr fixes this by returning from the `group.setData` method if there is a group being dragged.
- It also adds the className `timeline-group-is-dragging` to the `group.dom.label` and `group.dom.foreground` elements of the dragged group while it is being dragged and removes it on the drag end event.
- You can test the `groupsEditable.html` example to confirm that the bug is fixed.

PS. Lines 1919-1973 in the `_onGroupDrag` method and lines 1996-2034 in `_onGroupDragEnd` method of ItemSet.js dont appear to do anything.