### PR TITLE
bugfix #86 Timeline Tooltips still visible after deleting an item

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1389,6 +1389,11 @@ class ItemSet extends Component {
 
     // remove from group
     item.parent && item.parent.remove(item);
+
+    // remove Tooltip from DOM
+    if (this.popup != null) {
+      this.popup.hide();
+    }
   }
 
   /**


### PR DESCRIPTION
I hope this PR fixes the issue https://github.com/yotamberk/timeline-plus/issues/86
(this is my first PR) 