### PR TITLE
Week plotting stuff

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -554,7 +554,9 @@ class TimeStep {
     // noinspection FallThroughInSwitchStatementJS
     switch (this.scale) {
       case 'week':
-        if(this.isMajor() && date.weekday() !== 0){
+        // Don't draw the minor label if this date is the first day of a month AND if it's NOT the start of the week.
+        // The 'date' variable may actually be the 'next' step when called from TimeAxis' _repaintLabels.
+        if(date.date() === 1 && date.weekday() !== 0){
             return "";
         }
       default: // eslint-disable-line no-fallthrough

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -708,7 +708,7 @@ TimeStep.FORMAT = {
     hour:       'HH:mm',
     weekday:    'ddd D',
     day:        'D',
-    week:       'D',
+    week:       'w',
     month:      'MMM',
     year:       'YYYY'
   },


### PR DESCRIPTION
I don't know why and when it got changed, but the week scale feature always stated that it depends on moment-locale and thus the week styling with 'w'.
The second commit addresse a probable bug: this.isMajor() may not actually return what you'd expect it to be, because this.current could be still set to the 'previous' value, if _repaintLabels in TimeAxis calls it.