### PR TITLE
Fix configurator error 

### DIFF
--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -277,7 +277,7 @@ let configureOptions = {
     tooltip: {
       followMouse: false,
       overflowMethod: 'flip',
-      delay: 500
+      delay: [500, 0, 99999, 100],
     },
     tooltipOnItemUpdateTime: false,
     type: ['box', 'point', 'range', 'background'],


### PR DESCRIPTION
Warning in console:

    dont know how to handle 500 delay Array(3)[ "global", "tooltip", "delay" ]

when opening the configurator by

```javascript
timeline.setOptions({configure: true})
```
