### PR TITLE
Pure CSS-based indentation of group levels

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -891,6 +891,14 @@ class Core {
       util.addClassName(dom.root, 'timeline-bottom');
     }
 
+    if (options.rtl) {
+      util.addClassName(dom.root, 'timeline-rtl');
+      util.removeClassName(dom.root, 'timeline-ltr');
+    } else {
+      util.addClassName(dom.root, 'timeline-ltr');
+      util.removeClassName(dom.root, 'timeline-rtl');
+    }
+
     // update root width and height options
     dom.root.style.maxHeight = util.option.asSize(options.maxHeight, '');
     dom.root.style.minHeight = util.option.asSize(options.minHeight, '');

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -199,7 +199,7 @@ class Group {
       if (!data.nestedGroups) {
         indent = indent + 15;
       }
-      util.addClassName(this.dom.label, 'vis-nested-group');
+      util.addClassName(this.dom.label, 'timeline-nested-group');
       if (this.itemSet.options && this.itemSet.options.rtl) {
         this.dom.inner.style.paddingRight = indent + 'px';
       } else {

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -180,18 +180,16 @@ class Group {
       }
 
       util.addClassName(this.dom.label, 'timeline-nesting-group');
-      var collapsedDirClassName = this.itemSet.options.rtl ? 'collapsed-rtl' : 'collapsed'
       if (this.showNested) {
-        util.removeClassName(this.dom.label, collapsedDirClassName);
+        util.removeClassName(this.dom.label, 'collapsed');
         util.addClassName(this.dom.label, 'expanded');
       } else {
         util.removeClassName(this.dom.label, 'expanded');
-        util.addClassName(this.dom.label, collapsedDirClassName);
+        util.addClassName(this.dom.label, 'collapsed');
       }
     } else if (this.nestedGroups) {
       this.nestedGroups = null;
-      collapsedDirClassName = this.itemSet.options.rtl ? 'collapsed-rtl' : 'collapsed'
-      util.removeClassName(this.dom.label, collapsedDirClassName);
+      util.removeClassName(this.dom.label, 'collapsed');
       util.removeClassName(this.dom.label, 'expanded');
       util.removeClassName(this.dom.label, 'timeline-nesting-group');
     }

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -195,16 +195,15 @@ class Group {
     }
 
     if (data && (data.treeLevel|| data.nestedInGroup)) {
-      var indent = 15 * (data.treeLevel || 2);
-      if (!data.nestedGroups) {
-        indent = indent + 15;
-      }
       util.addClassName(this.dom.label, 'timeline-nested-group');
-      if (this.itemSet.options && this.itemSet.options.rtl) {
-        this.dom.inner.style.paddingRight = indent + 'px';
+      if (data.treeLevel) {
+        util.addClassName(this.dom.label, 'timeline-group-level-' + data.treeLevel);
       } else {
-        this.dom.inner.style.paddingLeft = indent + 'px';
+        // Nesting level is unknown, but we're sure it's at least 1
+        util.addClassName(this.dom.label, 'timeline-group-level-unknown-but-gte1');
       }
+    } else {
+      util.addClassName(this.dom.label, 'timeline-group-level-0');
     }
     
     // update className

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1881,8 +1881,7 @@ class ItemSet extends Component {
       util.addClassName(group.dom.label, 'expanded');
     } else {
       util.removeClassName(group.dom.label, 'expanded');
-      const collapsedDirClassName = this.options.rtl ? 'collapsed-rtl' : 'collapsed';
-      util.addClassName(group.dom.label, collapsedDirClassName);
+      util.addClassName(group.dom.label, 'collapsed');
     }
   }
   

--- a/lib/timeline/component/css/itemset.css
+++ b/lib/timeline/component/css/itemset.css
@@ -37,12 +37,121 @@
   cursor: pointer;
 }
 
-.timeline-nested-group {
+.timeline-label.timeline-nested-group.timeline-group-level-unknown-but-gte1 {
   background: #f5f5f5;
 }
+.timeline-label.timeline-nested-group.timeline-group-level-0 {
+  background-color: #ffffff;
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-0 .timeline-inner {
+  padding-left: 0;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-0 .timeline-inner {
+  padding-right: 0;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-1 {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-1 .timeline-inner {
+  padding-left: 15px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-1 .timeline-inner {
+  padding-right: 15px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-2 {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-2 .timeline-inner {
+  padding-left: 30px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-2 .timeline-inner {
+  padding-right: 30px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-3 {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-3 .timeline-inner {
+  padding-left: 45px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-3 .timeline-inner {
+  padding-right: 45px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-4 {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-4 .timeline-inner {
+  padding-left: 60px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-4 .timeline-inner {
+  padding-right: 60px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-5 {
+  background-color: rgba(0, 0, 0, 0.25);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-5 .timeline-inner {
+  padding-left: 75px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-5 .timeline-inner {
+  padding-right: 75px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-6 {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-6 .timeline-inner {
+  padding-left: 90px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-6 .timeline-inner {
+  padding-right: 90px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-7 {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-7 .timeline-inner {
+  padding-left: 105px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-7 .timeline-inner {
+  padding-right: 105px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-8 {
+  background-color: rgba(0, 0, 0, 0.4);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-8 .timeline-inner {
+  padding-left: 120px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-8 .timeline-inner {
+  padding-right: 120px;
+}
+.timeline-label.timeline-nested-group.timeline-group-level-9 {
+  background-color: rgba(0, 0, 0, 0.45);
+}
+.timeline-ltr .timeline-label.timeline-nested-group.timeline-group-level-9 .timeline-inner {
+  padding-left: 135px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group.timeline-group-level-9 .timeline-inner {
+  padding-right: 135px;
+}
+/* default takes over beginning with level-10 (thats why we add .timeline-nested-group
+  to the selectors above, to have higher specifity than these rules for the defaults) */
+.timeline-label.timeline-nested-group {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.timeline-ltr .timeline-label.timeline-nested-group .timeline-inner {
+  padding-left: 150px;
+}
+.timeline-rtl .timeline-label.timeline-nested-group .timeline-inner {
+  padding-right: 150px;
+}
 
+.timeline-group-level-unknown-but-gte1 {
+  border: 1px solid red;
+}
 
 /* expanded/collapsed indicators */
+.timeline-label.timeline-nesting-group:before,
+.timeline-label.timeline-nesting-group:before {
+  display: inline-block;
+  width: 15px;
+}
 .timeline-label.timeline-nesting-group.expanded:before {
   content: "\25BC";
 }
@@ -51,6 +160,13 @@
 }
 .timeline-rtl .timeline-label.timeline-nesting-group.collapsed:before {
   content: "\25C0";
+}
+/* compensate missing expanded/collapsed indicator, but only at levels > 0 */
+.timeline-ltr .timeline-label:not(.timeline-nesting-group):not(.timeline-group-level-0) {
+  padding-left: 15px;
+}
+.timeline-rtl .timeline-label:not(.timeline-nesting-group):not(.timeline-group-level-0) {
+  padding-right: 15px;
 }
 
 .timeline-overlay {

--- a/lib/timeline/component/css/itemset.css
+++ b/lib/timeline/component/css/itemset.css
@@ -41,16 +41,16 @@
   background: #f5f5f5;
 }
 
+
+/* expanded/collapsed indicators */
 .timeline-label.timeline-nesting-group.expanded:before {
   content: "\25BC";
 }
-
-.timeline-label.timeline-nesting-group.collapsed-rtl:before {
-  content: "\25C0";
-}
-
 .timeline-label.timeline-nesting-group.collapsed:before {
   content: "\25B6";
+}
+.timeline-rtl .timeline-label.timeline-nesting-group.collapsed:before {
+  content: "\25C0";
 }
 
 .timeline-overlay {


### PR DESCRIPTION
Solution for https://github.com/yotamberk/timeline-plus/issues/103 "'Hard-coded' indent in nested groups":

The indentation is now styled via some new classes (`timeline-group-level-0`, `timeline-group-level-1` and so on...) and CSS, which allows custom styling for each level by overriding these styles.

Tested in current Firefox (Developer Edition) and Internet Explorer 11.

Notes:

- CSS includes support for then indentation levels and a fallback styling for all higher levels (each level gets a bit darker)
- RTL Mode is respected (there are classes `timeline-rtl` and `timeline-ltr`) for that
- I tried to retain the same appearance as before: e.g.
  - indentation of 15px per level (level 0 without indent)
  - different indentation of 30px for nested groups where level is unknown because `treeLevel` is missing from group data. (Note: group label gets class `timeline-group-level-unknown-but-gte1` in that case)
  -  background color for level 1 is same as originally intended (styled by class `timeline-nested-group`)
  - indent of groups without contained groups, which have no expanded/collapsed marker, is fixed to be in line with groups with contained groups on same level, *except* on top level

See enclosed commits, I tried to separate them as possible.

