### PR TITLE
Use reserved group IDs instead of hardcoded strings

### DIFF
--- a/lib/timeline/component/ClusterGenerator.js
+++ b/lib/timeline/component/ClusterGenerator.js
@@ -1,5 +1,7 @@
 import ClusterItem from './item/ClusterItem';
 
+import { ReservedGroupIds } from './ItemSet';
+
 export default class ClusterGenerator {
     /**
      * @param {ItemSet} itemSet itemsSet instance
@@ -149,7 +151,7 @@ export default class ClusterGenerator {
                             }
 
                             const groupId = this.itemSet.getGroupId(item.data);
-                            const group = this.itemSet.groups[groupId] || this.itemSet.groups['__ungrouped__'];
+                            const group = this.itemSet.groups[groupId] || this.itemSet.groups[ReservedGroupIds.UNGROUPED];
                             let cluster = this._getClusterForItems(clusterItems, group, oldClusters, options);
                             clusters.push(cluster);
 

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -1,6 +1,8 @@
 import * as util from '../../util';
 import * as stack from '../Stack';
 
+import { ReservedGroupIds } from './ItemSet';
+
 /**
  * @constructor Group
  */
@@ -425,7 +427,7 @@ class Group {
     for (let i = 0, ii = this.visibleItems.length; i < ii; i++) {
       const item = this.visibleItems[i];
       item.repositionY(margin);
-      if (!this.isVisible && this.groupId != "__background__") {
+      if (!this.isVisible && this.groupId != ReservedGroupIds.BACKGROUND) {
         if (item.displayed) item.hide();
       }
     }
@@ -817,7 +819,7 @@ class Group {
     const visibleItems = [];
     const visibleItemsLookup = {}; // we keep this to quickly look up if an item already exists in the list without using indexOf on visibleItems
 
-    if (!this.isVisible && this.groupId != "__background__") {
+    if (!this.isVisible && this.groupId != ReservedGroupIds.BACKGROUND) {
       for (let i = 0; i < oldVisibleItems.length; i++) {
         var item = oldVisibleItems[i];
         if (item.displayed) item.hide();

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -17,6 +17,11 @@ import ClusterGenerator from './ClusterGenerator';
 const UNGROUPED = '__ungrouped__';   // reserved group id for ungrouped items
 const BACKGROUND = '__background__'; // reserved group id for background items without group
 
+export const ReservedGroupIds = {
+  UNGROUPED,
+  BACKGROUND
+}
+
 /**
  * An ItemSet holds a set of items and ranges which can be displayed in a
  * range. The width is determined by the parent of the ItemSet, and the height


### PR DESCRIPTION
Less error prone as build process will complain now.

Are you OK with `ItemSet.js` as the location for the `ReservedGroupIds` export, or should I change it to another file?
