### PR TITLE
Allow a tooltip delay of 0 ms

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -585,10 +585,13 @@ class ItemSet extends Component {
   setPopupTimer(popup) {
     this.clearPopupTimer();
     if (popup) {
+      const delay = this.options.tooltip.delay || typeof this.options.tooltip.delay === 'number' ?
+            this.options.tooltip.delay :
+            500;
       this.popupTimer = setTimeout(
         function () {
           popup.show()
-        }, this.options.tooltip.delay || 500);
+        }, delay);
     }
   }
 


### PR DESCRIPTION
Workaround of setting a delay of `1` no more required.

Other falsy values still result in default timeout (500ms).