### PR TITLE
Fix events for labels of groups with nestedGroups

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1849,6 +1849,12 @@ class ItemSet extends Component {
 
   _onGroupClick(event) {
     const group = this.groupFromTarget(event);
+    setTimeout(() => {
+      this.toggleGroupShowNested(group);
+    }, 1)
+  }
+  
+  toggleGroupShowNested(group) {
 
     if (!group || !group.nestedGroups) return;
 

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1854,13 +1854,17 @@ class ItemSet extends Component {
     }, 1)
   }
   
-  toggleGroupShowNested(group) {
+  toggleGroupShowNested(group, force = undefined) {
 
     if (!group || !group.nestedGroups) return;
 
     const groupsData = this.groupsData.getDataSet();
 
-    group.showNested = !group.showNested;
+    if (force != undefined) {
+      group.showNested = !!force;
+    } else {
+      group.showNested = !group.showNested;
+    }
 
     let nestingGroup = groupsData.get(group.groupId);
     nestingGroup.showNested = group.showNested;


### PR DESCRIPTION
E.g. links can now be clicked in groups containing other groups, aswell.

Closes #140

Problem was the re-rendering of group labels for expanding/collapsing groups, which causes the originating event targets (e.g. links) to be removed from the DOM. The event now won't bubble up because there's no parent anymore (to my understanding). The timeout of 1 ms breaks the expand/collapse out of the event processing, which lets the browser finish the event processing before the DOM is being modified. Expand/collapse is performed after that, as soon as the browser is idle again.

Note: group still exands/collapses when clicked on the link, and this is quite noticeable for the user. But I found no way to prevent this behavior.