### PR TITLE
Fix initially hidden large items spanning the whole visible range (extended by 25% to the …

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -827,7 +827,20 @@ class Group {
       return visibleItems;
     } 
 
-    const interval = (range.end - range.start) / 4;
+    const rangeDuration = range.end - range.start;
+    let interval = rangeDuration / 4;
+    
+    for (let i = 0; i < orderedItems.byEnd.length; i++) {
+      const item = orderedItems.byEnd[i];
+
+      const duration = item.data.end - item.data.start;
+      const maxProtruding = duration - rangeDuration;
+
+      if (maxProtruding > interval) {
+        interval = maxProtruding;
+      }
+    }
+
     const lowerBound = range.start - interval;
     const upperBound = range.end + interval;
 


### PR DESCRIPTION
Large items spanning the whole visible range (extended by 25% to the left and right as a "buffer zone") are initially hidden until their start or end scrolls into that range.

This commit fixes this by increasing the buffer zone depending on the items, so that its large enough to fit all potentially visible (not all!) items.

The current implementation has a **performance-related drawback**:

As the whole "scanning range" is enlarged, more items need to be processed and more items will be visible. I see no problems for light datasets, but for large datasets with many items - especially item types without end date - this could become a problem. Possible solutions:

1. add an option to choose: have this fix with the performance drawback, or tolerate the bug but with higher performance for large, mixed datasets
2. two scanning passes:
    * first pass using the extended buffer zone (as implemented in this patch) just for ranged items (items with start and end)
    * second pass with fixed buffer zone (as before) for items without end
3. more than two scanning passes: similar to 2., but items with start and end could be depending on their duration grouped into scanning passes with different scanning ranges (different buffer zones). Fixed buffer zone (as before) for items without end.

**This needs to be discussed.** @yotamberk, @taavi-halkola, others: you opinion?

The implementation should additionally be **optimised by caching maximum item duration** per group:

Maximum duration is calculated per group at rendering level, which happens more often than needed.
Possible solution: calculate on item changes and cache it. Should be easy to fix for someone who knows the location where this could be implemented without missing any changes.

**This should be implemented.** @yotamberk Do you know a suitable location?

I think the initial buffer zone size should also be configurable, currently at 1/2 of visible range (1/4 to the left, 1/4 to the right).

@yotamberk Are you OK with this?

