### PR TITLE
Avoid babel polyfill collision when loaded multiple times by differen…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,7 @@ const webpackModule = {
 };
 
 const webpackConfig = {
-  entry: ["@babel/polyfill", ENTRY],
+  entry: ["@babel/polyfill/noConflict", ENTRY],
   output: {
     library: 'timeline',
     libraryTarget: 'umd',


### PR DESCRIPTION
Babel-polyfill is embedded in the published version of timeline-plus, which cause trouble when integrating with other libraries using this polyfill too.

In fact, I'm a bit surprised of the issue, because it looks that babel polyfill is added as devDependencies in your project (strange regarding documentation which specify that it should be added as a dependency https://babeljs.io/docs/en/babel-polyfill) but despite this, the polyfill is still part of the published version.

The issue with babel-polyfill (I think it depends on the version of babel), is that if you add it twice, it will raise an error instead of just a warning. A trick has been added to babel (https://github.com/babel/babel/pull/6371) for muting the double import (which is probably a better approach when using polyfill in a library).
