### PR TITLE
Change return conditions in onUpdate

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2236,7 +2236,9 @@ class ItemSet extends Component {
    */
   _onUpdateItem(item) {
     if (!this.options.selectable) return;
-    if (!this.options.editable.add) return;
+    if (!this.options.editable.updateTime) return;
+    if (!this.options.editable.updateGroup) return;
+
 
     const me = this;
    


### PR DESCRIPTION
Attemp to solve https://github.com/yotamberk/timeline-plus/issues/169

In onUpdate method I have changed the return conditions to the defined in documentation:

> **onUpdate**: Callback function triggered when an item is about to be updated, when the user double taps an item in the Timeline. See section Editing Items for more information. **Only applicable when both options selectable and editable.updateTime or editable.updateGroup are set true.**