### PR TITLE
Press and drag selected item

### DIFF
--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -171,6 +171,9 @@ class Item {
           item: me.id
         });
       });
+      this.hammer.on('panstart', me.parent.itemSet._onDragStart.bind(me.parent.itemSet));
+      this.hammer.on('panmove',  me.parent.itemSet._onDrag.bind(me.parent.itemSet));
+      this.hammer.on('panend',   me.parent.itemSet._onDragEnd.bind(me.parent.itemSet));
 
       if (this.dom.box) {
         if (this.dom.dragLeft) {


### PR DESCRIPTION
When an already selected item is 'pressed' (clicked for longer than 250ms) it cannot be dragged (e.g. to another group) anymore.
This is, because the drag events are not forwarded to the item set handler methods.